### PR TITLE
[sukhee-fileupload] 게시글에 첨부된 사진이 있는 경우, 게시글 보기에서 사진이 보이도록 수정.

### DIFF
--- a/src/main/java/com/mycompany/webapp/controller/BoardController.java
+++ b/src/main/java/com/mycompany/webapp/controller/BoardController.java
@@ -124,8 +124,9 @@ public class BoardController {
 		if (!board.getBattach().isEmpty()) { // Multipartfile은 넘어오지 않아도 null값이 아니라 객체 하나가 들어가서 null로 체크하지 않는다.
 			board.setBimageoriginalfilename(board.getBattach().getOriginalFilename());
 			board.setBimagecontenttype(board.getBattach().getContentType());
-			board.setBimageoriginalfilename(new Date().getTime() + "-" + board.getBimageoriginalfilename());
-			File file = new File("C:/Temp/uploadfiles/" + board.getBimagesavedfilename());
+			board.setBimageoriginalfilename(board.getBimageoriginalfilename());
+			board.setBimagesavedfilename(new Date().getTime() + "-" + board.getBimageoriginalfilename());
+			File file = new File("/Users/choisukhee/Documents/2022/오스템 임플란트/중간 프로젝트/fileStorage/" + board.getBimagesavedfilename());
 			board.getBattach().transferTo(file);
 		}
 

--- a/src/main/java/com/mycompany/webapp/controller/BoardController.java
+++ b/src/main/java/com/mycompany/webapp/controller/BoardController.java
@@ -2,17 +2,14 @@ package com.mycompany.webapp.controller;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.InputStream;
 import java.net.URLEncoder;
 import java.util.Date;
 import java.util.List;
 
 import javax.annotation.Resource;
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
-import org.apache.commons.io.IOUtils;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.util.FileCopyUtils;
@@ -22,7 +19,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
 
 import com.mycompany.webapp.dto.Board;
 import com.mycompany.webapp.dto.Comment;

--- a/src/main/java/com/mycompany/webapp/controller/BoardController.java
+++ b/src/main/java/com/mycompany/webapp/controller/BoardController.java
@@ -1,18 +1,28 @@
 package com.mycompany.webapp.controller;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.net.URLEncoder;
 import java.util.Date;
 import java.util.List;
 
 import javax.annotation.Resource;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
+import org.apache.commons.io.IOUtils;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.util.FileCopyUtils;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 import com.mycompany.webapp.dto.Board;
 import com.mycompany.webapp.dto.Comment;
@@ -90,6 +100,41 @@ public class BoardController {
 		String userid = (String) session.getAttribute("sessionUserid");
 		model.addAttribute("userid", userid);
 		return "board/boardDetail";
+	}
+	
+	@GetMapping(value="/boardDetailAttachedFile") //파일이 첨부된 게시글인 경우, 파일을 보여줌.
+	public void boardDetailAttachedFile(
+//			@RequestParam("boardno") int boardno
+			@ModelAttribute("boardno") int boardno
+			, @RequestHeader("User-Agent") String userAgent
+			, HttpServletResponse response) throws Exception {//void: 직접 응답을 만들것.
+		if(boardService.getBoard(boardno).getBimagesavedfilename() != null) {//게시물번호로 조회해서, 첨부된 파일이 있는지 조회. 있다면, 전송.
+			log.info("실행");
+			//DB에서 가져올 정보
+			String originalFilename = boardService.getBoard(boardno).getBimageoriginalfilename();
+			String saveFilename = boardService.getBoard(boardno).getBimagesavedfilename();
+//			String userAgent = (String) model.get("userAgent");
+			//응답 내용의 데이터 타입을 응답 헤더에 추가
+			response.setContentType(boardService.getBoard(boardno).getBimagecontenttype());
+			
+			if(userAgent.contains("Trident") || userAgent.contains("MSIE")) {
+				//IE 브라우저일 경우
+				originalFilename = URLEncoder.encode(originalFilename, "UTF-8");
+			} else {
+				//크롬, 엣지, 사파리일 경우
+				originalFilename = new String(originalFilename.getBytes("UTF-8"), "ISO-8859-1");
+			}
+			response.setHeader("Content-Disposition", "attachment; filename=\"" + originalFilename + "\"");
+			
+			//파일 데이터를 응답 본문에 싣기
+			File file = new File("/Users/choisukhee/Documents/2022/오스템 임플란트/중간 프로젝트/fileStorage/" + saveFilename);
+			if(file.exists()) {
+				FileCopyUtils.copy(
+					new FileInputStream(file)
+					, response.getOutputStream()
+				);
+			}
+		}
 	}
 	
 	@RequestMapping("/boardWriteForm")

--- a/src/main/resources/spring/dispatcher/multipart_resolver..xml
+++ b/src/main/resources/spring/dispatcher/multipart_resolver..xml
@@ -2,10 +2,13 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	
+	<!-- 모든 서블릿 버전에서 사용 가능한 방법 -->
+	<!-- <bean id="multipartResolver"
+			class="org.springframework.web.multipart.commons.CommonsMultipartResolver"/> -->
+	
+	<!-- 서블릿 3.0 이상 버전에서만 사용 가능한 방법 -->
+	<bean id="multipartResolver"
+		class="org.springframework.web.multipart.support.StandardServletMultipartResolver"/>
 
-	<!-- 모든 서블릿 버젼에서 사용 가능한 방법 -->
-	<!-- <bean id="multipartResolver" class="org.springframework.web.multipart.commons.CommonsMultipartResolver" /> -->
-
-	<!-- 서블릿 3.0 이상 버젼에서만 사용 가능한 방법 -->
-	<bean id="multipartResolver" class="org.springframework.web.multipart.support.StandardServletMultipartResolver" />
 </beans>

--- a/src/main/webapp/WEB-INF/views/board/boardDetail.jsp
+++ b/src/main/webapp/WEB-INF/views/board/boardDetail.jsp
@@ -20,6 +20,21 @@
 }
 </style>
 </head>
+<script>
+	$.ajax({
+		url: "boardDetailAttachedFile?boardno=" + ${board.boardno},
+		method:"GET",
+	})
+	.done((data) => {
+		console.log('data : ' + data);
+		console.log('typeof data : ' + typeof data);
+		if(data == '') {
+			$('#attachedImg').attr("style", "display:none");
+		} else {
+			$('#attachedImg').attr("src", "boardDetailAttachedFile?boardno=" + ${board.boardno});
+		}
+	});
+</script>
 <body>
 	<%@ include file="/WEB-INF/views/common/header.jsp"%>
 	
@@ -48,8 +63,7 @@
 			<div>${board.boardcontent}</div>
 			
 			<div>
-				<img src="${pageContext.request.contextPath}/resources/images/puppy3.jpeg" width="50%" height="100rem;">
-				<img src="${pageContext.request.contextPath}/resources/images/puppy1.jpeg" width="50%" height="100rem;">
+				<img id="attachedImg" width="50%" height="100rem;">
 			</div>
 			
 			<div style="text-align: left;" class="mt-2">

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -34,8 +34,8 @@
 		<!-- Servlet 3.0에서 지원하는 multipart/form-data 파싱 기능을 위한 설정 -->
 		<multipart-config>
 			<!-- 임시 파일이 저장될 폴더의 절대 경로만 가능 -->
-			<!-- <location>/Users/choisukhee/Documents/2022/오스템 임플란트/temp</location> -->
-			<location>C:/temp</location>
+			 <location>/Users/choisukhee/Documents/2022/오스템 임플란트/중간 프로젝트/fileStorage/</location>
+			<!-- <location>C:/temp</location> -->
 			<!-- <location>C:/</location> -->
 			<!-- 파일 크기가 10MB 이하만 허용(1024*1024*10) -->
 			<max-file-size>10485760</max-file-size>


### PR DESCRIPTION
게시글에 첨부된 사진이 있는 경우, 게시글 보기에서 사진이 보이도록 수정.
- BoardController.java 사용자가 게시글에 이미지를 첨부하면 DB에 저장하고, 이후에 해당 글 상세보기시에
이미지를 전송.
- boardDetail.jsp ajax통신을 이용해서 게시글에 첨부된 이미지가 있는경우 응답받아서 img태그에 넣어줌.(첨부된
이미지가 없는 경우 img태그는 display:none 속성.)
- multipart_resolver.xml 파일 자체를 리턴하기 위해서 추가.