### PR TITLE
#223 feat: 리스트아이템마다 썸네일 띄워주는 기능 구현(treatment 메인목록, 내치과 메인목록) 

### DIFF
--- a/src/main/webapp/WEB-INF/views/myPage/myDentist.jsp
+++ b/src/main/webapp/WEB-INF/views/myPage/myDentist.jsp
@@ -37,9 +37,17 @@
 				<div class="dentist-list-item" data-dendomain="${myDentist.dendomain}" data-denname="${myDentist.denname}">
 					<div class="dentist-list-item__main-body">
 						<div class="main-body__col">
-							<div class="main-body__img"></div>
+							<div class="main-body__img-box">
+								<img onerror="handleLoadError(event)" src="http://localhost:${myDentist.dendomain}/springframework-mini-project-dentist/deninfo/getDentistImage" alt="dentist thumbnail"/>
+							</div>
 							<div class="main-body__nametag">
-								<p class="name overflow-ellipsis">${myDentist.denname}</p>
+								<p class="name overflow-ellipsis">
+									${myDentist.denname}
+									<span class="subtitle">
+										<i class="fa-solid fa-circle-check"></i>
+										내 치과
+									</span>
+								</p>
 								<span class="address overflow-ellipsis">${myDentist.denaddress}</span>
 							</div>
 						</div>
@@ -94,9 +102,20 @@
 						<div class="dentist-list-item" data-dendomain="${searchedDentist.dendomain}" data-denname="${searchedDentist.denname}">
 							<div class="dentist-list-item__main-body">
 								<div class="main-body__col">
-									<div class="main-body__img"></div>
+									<div class="main-body__img-box">
+										<img onerror="handleLoadError(event)" src="http://localhost:${searchedDentist.dendomain}/springframework-mini-project-dentist/deninfo/getDentistImage" alt="dentist thumbnail"/>
+									</div>
 									<div class="main-body__nametag">
-										<p class="name overflow-ellipsis">${searchedDentist.denname}</p>
+										<p class="name overflow-ellipsis">
+											${searchedDentist.denname}
+											<%-- 내치과일 경우에만 '내치과' 딱지 붙여줌 --%>
+											<c:if test="${fn:contains(myDentists, searchedDentist)}">
+												<span class="subtitle">
+													<i class="fa-solid fa-circle-check"></i>
+													내 치과
+												</span>		
+											</c:if>
+										</p>
 										<span class="address overflow-ellipsis">${searchedDentist.denaddress}</span>
 									</div>
 								</div>
@@ -109,10 +128,18 @@
 							<%-- 바디 클릭하면 보이는 드롭다운메뉴--%>
 							<div class="dentist-list-item__dropdown-menu-list basic-shadow" style="display: none;">
 								<ol class="menu-list">
-									<li class="menu-btn add-btn"
-										data-toggle="modal" data-target="#confirmModal">
-										내 치과 목록에 추가하기
-									</li>
+									<%-- 내치과일 경우에는 비활성화하기 --%>
+									<c:if test="${fn:contains(myDentists, searchedDentist)}">
+										<li class="menu-btn add-btn menu-btn-disabled">
+											내 치과 목록에 추가하기
+										</li>
+									</c:if>
+									<c:if test="${not fn:contains(myDentists, searchedDentist)}">
+										<li class="menu-btn add-btn"
+											data-toggle="modal" data-target="#confirmModal">
+											내 치과 목록에 추가하기
+										</li>
+									</c:if>
 								</ol>
 							</div>
 						</div>
@@ -208,6 +235,12 @@
 			}
 			return true;			
 		}
+		
+		// 치과당 썸네일 로드할때 에러날때 더미이미지로 대체
+		function handleLoadError(event){
+			const errorTarget = event.target;
+			errorTarget.src = "${pageContext.request.contextPath}/resources/images/no-image.jpg";
+		}
 
 		$(function() {
 			// 치과당 클릭할 때 클릭된 타겟의 드롭다운 토글하기
@@ -232,6 +265,7 @@
 					location.href = "myDentist?dendomain=" + targetDendomain + "&task=" + task;
 				});
 			});
+
 		})
 	</script>
 

--- a/src/main/webapp/WEB-INF/views/treatment/details.jsp
+++ b/src/main/webapp/WEB-INF/views/treatment/details.jsp
@@ -240,12 +240,12 @@
 			attachmentList.map(({isafter, savedfilename}) => {
 				if (!isafter) {
 					$(".before-imgs-wrapper").append(
-						"<a href='imageShow?filename="+savedfilename+"'><img class='content__img' src='http://localhost:" + '${dendomain}' + "/springframework-mini-project-dentist/resources/images/treatment/"+ savedfilename +"' alt='before image'/></a>"
+						"<a href='imageShow?filename=" + savedfilename + "'><img class='content__img' src='http://localhost:" + '${dendomain}' + "/springframework-mini-project-dentist/resources/images/treatment/"+ savedfilename +"' alt='before image'/></a>"
 					);
 				}
 				if (isafter) {
 					$(".after-imgs-wrapper").append(
-						"<a href='imageShow?filename="+savedfilename+"'><img class='content__img' src='http://localhost:" + '${dendomain}' + "/springframework-mini-project-dentist/resources/images/treatment/"+ savedfilename +"' alt='after image'/></a>"
+						"<a href='imageShow?filename=" + savedfilename + "'><img class='content__img' src='http://localhost:" + '${dendomain}' + "/springframework-mini-project-dentist/resources/images/treatment/"+ savedfilename +"' alt='after image'/></a>"
 					);
 				}
 			});

--- a/src/main/webapp/WEB-INF/views/treatment/details.jsp
+++ b/src/main/webapp/WEB-INF/views/treatment/details.jsp
@@ -14,7 +14,6 @@
 	<main class="main located-at-bottom-of-header">
 	
 		<h1 class="page-title" id="treatment-type">충치 치료</h1>
-		<span>#<span id="treatno">00</span></span>
 	    <section class="mouth-section">
 	        <div class="mouth">
 	            <div class="mouth__upper-jaw">
@@ -216,10 +215,10 @@
 			console.log(data);
 
 			const treattype = data.treattype;
-			$("#treatment-type").html(treattype);
-
 			const treatno = data.treatno;
-			$("#treatno").html(treatno);
+			$("#treatment-type").html(treattype);
+			$("#treatment-type").append(`<span>  #<span id="treatno">` + treatno + `</span></span>`);
+			
 
 			// 동적으로 표시해야 할 치아들을 각각 색깔로 표시하기
 			const teeth = data.teeth;
@@ -238,15 +237,15 @@
 		    
 			// 이미지 동적으로 랜더링
 			const attachmentList = data.attachmentList;
-			attachmentList.map(({bsavedfilename, asavedfilename}) => {
-				if (bsavedfilename) {
+			attachmentList.map(({isafter, savedfilename}) => {
+				if (!isafter) {
 					$(".before-imgs-wrapper").append(
-						"<a href='imageShow?filename="+bsavedfilename+"'><img class='content__img' src='http://localhost:8082/springframework-mini-project-dentist/resources/images/treatment/"+ bsavedfilename +"' alt='dummy'/></a>"
+						"<a href='imageShow?filename="+savedfilename+"'><img class='content__img' src='http://localhost:" + '${dendomain}' + "/springframework-mini-project-dentist/resources/images/treatment/"+ savedfilename +"' alt='before image'/></a>"
 					);
 				}
-				if (asavedfilename) {
+				if (isafter) {
 					$(".after-imgs-wrapper").append(
-						"<a href='imageShow?filename="+asavedfilename+"'><img class='content__img' src='http://localhost:8082/springframework-mini-project-dentist/resources/images/treatment/"+ asavedfilename +"' alt='dummy'/></a>"
+						"<a href='imageShow?filename="+savedfilename+"'><img class='content__img' src='http://localhost:" + '${dendomain}' + "/springframework-mini-project-dentist/resources/images/treatment/"+ savedfilename +"' alt='after image'/></a>"
 					);
 				}
 			});

--- a/src/main/webapp/WEB-INF/views/treatment/main.jsp
+++ b/src/main/webapp/WEB-INF/views/treatment/main.jsp
@@ -89,26 +89,29 @@
 				window.location.href = "details?treatno=" + treatno + "&dendomain=" + dendomain;
 			});
 		}
-	 	
-	 	// function getdendomainByDendomain(dendomain) {
-	    //    // data-dendomain값을 리스트아이템마다 동적으로 지정하기 위해 각 객체의 dendomain값이 필요하기 때문에,
-	    //    // 현재 페이지가 갖고 있는 dendomain 정보로써 dendomain값이 뭔지 user서버 단에 쿼리 날리는 함수
-	 	// 	let dendomain = null;
-	 	// 	$.ajax({
-	 	// 		type: "POST",
-	 	// 		url: "${pageContext.request.contextPath}/dentist/getdendomainByDendomain?dendomain=" + dendomain,
-	 	// 		async: false
-	 	// 	}).done((data) => {
-	 	// 		dendomain = data.dendomain;
-	 	// 	});
-	 	// 	return dendomain;
-	 	// }
-	 	
-		function template({treatno, dendomain, treattype, denname, treatdate}) {
-			// const dendomain = getdendomainByDendomain(dendomain);
-			
-			return `
 
+	 	
+		function template({treatno, dendomain, treattype, denname, treatdate}, IMAGE_FILENAME) {
+			if(IMAGE_FILENAME) {
+				return `
+					<div class="list-item hover-effect" data-treatno="` + treatno + `" data-dendomain="`+ dendomain +`">
+		
+						<div class="list-item__info-summary">
+							<h4 class="title">
+								`+ treattype +`
+								<span class="subtitle">`+ denname +`</span>
+							</h4>
+						<p class="text-md">`+ treatdate +`</p>
+					</div>
+					<div class="list-item__thumbnail">
+						<!--TBD: 객체가 attachment를 갖고 있다면 before 사진 중 첫번째 이미지를 썸네일로 띄우기-->
+						<!--TBD: 만약 before 사진이 하나도 없다면 after 사진 중 첫번째 이미지를 썸네일로 띄우기-->
+						<img class="list-item-thumbnail" src="http://localhost:` + dendomain + `/springframework-mini-project-dentist/resources/images/treatment/` + IMAGE_FILENAME + `" alt="treatment thumbnail image"/>
+					</div>
+				</div>
+				`;
+			}
+			return `
 				<div class="list-item hover-effect" data-treatno="` + treatno + `" data-dendomain="`+ dendomain +`">
 
 					<div class="list-item__info-summary">
@@ -121,7 +124,7 @@
 				<div class="list-item__thumbnail">
 	            	<!--TBD: 객체가 attachment를 갖고 있다면 before 사진 중 첫번째 이미지를 썸네일로 띄우기-->
 	            	<!--TBD: 만약 before 사진이 하나도 없다면 after 사진 중 첫번째 이미지를 썸네일로 띄우기-->
-	            	<img src="https://dummyimage.com/600x400/000/fff" alt="treatment thumbnail image"/>
+	            	<img class="list-item-thumbnail" src="${pageContext.request.contextPath}/resources/images/no-image.jpg" alt="treatment thumbnail image"/>
             	</div>
            	</div>
            	`;
@@ -137,7 +140,6 @@
 			}
 
 			function getTreatments(selectedTreattype) {
-				console.log(selectedTreattype);
 				const promise = new Promise((resolve, reject) => {
 					let list = [];
           			console.log("dentist", ${dentist}.dentist);
@@ -160,15 +162,13 @@
 					} else {
 						reject({message: "실패"});
 					}
-				})
+				});
 				return promise;
 			}
 	
 			async function getData(selectedTreattype) {
 				try {
 					data = await getTreatments(selectedTreattype);
-					// TBD: 아래 smalldata들 다시 data로 바꾸기(테스트할때 너무 오래걸려서 smalldata로 해둠)
-					
 					// 만약 해당 내역이 없을 경우 없다고 표시
 					if (!data.length) {
 						const emptyBlockTemplate = `
@@ -194,9 +194,29 @@
 					//console.log("orderedDate:", data);
 					//console.log(data.length);
 					$(".selected-treattype-results-section").html("");
+					let IMAGE_FILENAME = null;
 					data.forEach(treatment => {
-		                 const listItem = template(treatment);
-		                 $(".selected-treattype-results-section").append(listItem);
+						$.ajax({
+							method:"POST",
+							url: "http://localhost:" + treatment.dendomain + "/springframework-mini-project-dentist/attachment/getAttachmentList?treatno=" + treatment.treatno,
+							data: {},
+							async: false
+						}).done((data) => {
+							console.log("hey loook!!!!!!!!!!!!!!!!!!!");
+							//console.log(data.attachments.);
+//							<!--TBD: 객체가 attachment를 갖고 있다면 before 사진 중 첫번째 이미지를 썸네일로 띄우기-->
+//							<!--TBD: 만약 before 사진이 하나도 없다면 after 사진 중 첫번째 이미지를 썸네일로 띄우기-->
+							if (data.attachments) {
+								data.attachments.forEach(({isafter, savedfilename}) => {
+									if(!isafter) {
+										IMAGE_FILENAME = savedfilename;
+										return false;
+									}
+								});
+							}
+						});
+						const listItem = template(treatment, IMAGE_FILENAME);
+						$(".selected-treattype-results-section").append(listItem);
 		             });
 				} catch (error) {
 					console.log(error, "error");

--- a/src/main/webapp/resources/css/myPage/myDentist.css
+++ b/src/main/webapp/resources/css/myPage/myDentist.css
@@ -26,27 +26,50 @@
 .dentist-list-item__main-body:hover {
 	cursor: pointer;
 	background-color: var(--pale-peach);
+	box-shadow: var(--basic-shadow);
 }
 .main-body__col {
 	display: flex;
 }
-.main-body__img {
+.main-body__img-box {
+	display: flex;
+	justify-content: center;
+	align-items: center;
 	background-color: var(--divider-gray);
 	min-width: 3.7rem;
 	min-height: 3.7rem;
+	width: 3.7rem;
+	height: 3.7rem;
 	border-radius: 50%;
+	overflow: hidden;
 	margin-right: 0.8rem;
+	box-shadow: 0px 0px 5px 1px rgb(0 0 0 / 20%);
+}
+.main-body__img-box > img {
+	object-fit: cover;
+	width: 100%;
 }
 .main-body__nametag {
 	display: flex;
 	flex-direction: column;
 }
 .main-body__nametag > .name {
+	display: flex;
+	align-items: center;
 	color: var(--osstem-orange);
 	font-size: 1.5rem;
 	font-weight: 500;
 	margin-top: 0.2rem;
 	margin-bottom: 0.3rem;
+}
+.main-body__nametag .subtitle {
+	display: inline-block;
+	color: var(--dark-gray);
+	font-size: 0.9rem;
+	margin-left: 0.4rem;
+}
+.main-body__nametag .subtitle > i {
+	margin-right: 0.1rem;
 }
 .main-body__nametag > .address {
 	font-size: 1.2rem;
@@ -90,6 +113,15 @@
 .dentist-list-item__dropdown-menu-list .menu-btn:hover {
 	cursor: pointer;
 	background-color: var(--pale-peach);
+}
+.menu-btn-disabled {
+	cursor: not-allowed !important;
+	background-color: var(--divider-gray);
+	color: var(--light-gray) !important;
+}
+.menu-btn-disabled:hover {
+	background-color: var(--divider-gray) !important;
+	color: var(--light-gray);
 }
 
 


### PR DESCRIPTION
#223 

**구현 후 모습**
<div style="display:flex;">
<img src="https://user-images.githubusercontent.com/18097984/168026200-72e0d296-3c54-47fb-941f-ba148c86bd3a.png" width="30%"/>
<img src="https://user-images.githubusercontent.com/18097984/168026356-c081bd2f-00a2-45ae-a1d6-9332c7074267.png" width="30%"/>
</div>

#### 추가 구현 기능
- 내치과 메인목록화면에서 내 치과인 치과는 '내 치과' 배지 붙여줌
- 검색결과 목록에서 내 치과일경우 '내 치과목록에 추가하기' 버튼이 비활성화되고 클릭되지 않도록 구현
- hover시 그림자 생기도록 기능 추가